### PR TITLE
Add aicoe-ci configuration to build the image

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,2 +1,10 @@
 ---
-check: []
+check:
+  - thoth-build
+build:
+  build-stratergy: Dockerfile  # Allowed values: Source, Dockerfile, Containerfile (default: Source)
+  dockerfile-path: Dockerfile
+  registry: "quay.io"
+  registry-org: "thoth-station"
+  registry-project: "meteor-operator"
+  registry-secret: "thoth-station-thoth-pusher-secret"


### PR DESCRIPTION
Add an `.aicoe-ci.yaml` that allows the pipelines to build the image for the operator.