### PR TITLE
Base version on 'git describe --tags'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,14 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.1.0
+
+_VERSION := $(shell git describe --tags --dirty)
+VERSION ?= ${_VERSION}
+
+.PHONY: version
+
+version:
+	@echo ${VERSION}
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
-_VERSION := $(shell git describe --tags --dirty)
+_VERSION := $(shell git describe --tags --dirty --always)
 VERSION ?= ${_VERSION}
 
 .PHONY: version


### PR DESCRIPTION
This makes the version based on `git describe --tags`, which is
basically `<most recent tag>-<number of commits since that tag>-<commit
hash>`

This is useful for us for development, because it lets us push distinct
images tags and avoid confusion when deploying new manifests on a test
environment.

However, it will take more storage on quay.io.
