### PR TITLE
Use the full image name for the golang image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM quay.io/projectquay/golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
The image build (checks) done by aicoe-ci are currently failing:

``` text
++ buildah bud --tls-verify=false --layers -f /gen-source/Containerfile -t meteor-operator-110 .
+ out='[1/2] STEP 1/10: FROM golang:1.18 AS builder
error creating build container: short-name resolution enforced but cannot prompt without a TTY'
+ exit_code=125
```

This is due to [podman and buildah requiring configuration for short names](https://www.redhat.com/sysadmin/container-image-short-names).

This PR changes the `golang` image short name to point to its resolved name instead.