### PR TITLE
Test that cnbi maintain a correct state

### DIFF
--- a/controllers/cnbi/controller_test.go
+++ b/controllers/cnbi/controller_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	timeout  = time.Second * 80
+	timeout  = time.Second * 30
 	interval = time.Millisecond * 750
 )
 
@@ -63,12 +63,14 @@ var _ = Describe("CustomNBImage controller", func() {
 
 			lookupKey := types.NamespacedName{Name: "test-1", Namespace: "default"}
 
-			Eventually(func(g Gomega) {
-				createdCNBi := &meteorv1alpha1.CustomNBImage{}
-				err := k8sClient.Get(ctx, lookupKey, createdCNBi)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(createdCNBi.Status.Conditions).ToNot(BeEmpty())
-				g.Expect(createdCNBi.Status.Phase).To(Equal(meteorv1alpha1.PhaseRunning))
+			Eventually(func(gg Gomega) {
+				gg.Consistently(func(g Gomega) {
+					createdCNBi := &meteorv1alpha1.CustomNBImage{}
+					err := k8sClient.Get(ctx, lookupKey, createdCNBi)
+					g.Expect(err).NotTo(HaveOccurred())
+					g.Expect(createdCNBi.Status.Conditions).ToNot(BeEmpty())
+					g.Expect(createdCNBi.Status.Phase).To(Equal(meteorv1alpha1.PhaseRunning))
+				}, "8s", "500ms").Should(Succeed())
 			}, timeout, interval).Should(Succeed())
 
 		})


### PR DESCRIPTION
Adding the Consistently inside the Eventually means:

Eventually, the CNBi resource should keep those assertions valid for
some time.
That way, we should catch more cases of non-stable state (the controller
set the correct conditions, then degrade the state because of a logic
bug).
