### PR TITLE
Do not include 'dirty' in image version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
-_VERSION := $(shell git describe --tags --dirty --always)
+_VERSION := $(shell git describe --tags --always)
 VERSION ?= ${_VERSION}
 
 .PHONY: version


### PR DESCRIPTION
The `--dirty` flag in `git describe` to determine the image version gets a bit in the way. E.g. when testing a certain PR, this workflow fails:

1. checkout branch
2. `export IMAGE_TAG_BASE=quay.io/myown/meteor-operator`
3. `make docker-build`. This builds an image version which is not dirty, but usually also has side effects of touching some generated file
4. `make docker-push` now fails because the new image version is `...-dirty`.

In this case, to make matters worse, the actual image content would be the same - just the tag changes.

I know you can do `make docker-build docker-push` to avoid the example above, but I often find myself fighting an unexpected `...-dirty`.

Are there any advantages of keeping it?

Semantically, honestly I already expect image version `v0.1.0-48-g2fa2545` to be a bit *dirty*...