### PR TITLE
Upgrade openshift-pipelines version to 1.8.*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ metadata:
   name: openshift-pipelines-operator
   namespace: openshift-operators
 spec:
-  channel: pipelines-1.7
+  channel: pipelines-1.8
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
On 1.7, we can't use a parameters for the image when using stepTemplate.
Upstream report: https://github.com/tektoncd/pipeline/issues/4801
