### PR TITLE
PEP 517 minimal git repo pipeline

### DIFF
--- a/pipelines/tasks/kustomization.yaml
+++ b/pipelines/tasks/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
 - extract-external-service.yaml
 - generate-jupyterhub.yaml
 - get-package-versions-list.yaml
+- python-build-wheel.yaml
 - resolve-owner-reference.yaml
 - validate-jupyterhub-image.yaml

--- a/pipelines/tasks/python-build-wheel.yaml
+++ b/pipelines/tasks/python-build-wheel.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: python-build-wheel
+spec:
+  description: |
+    Build a package (from source_code) into a wheel (in wheel_storage)
+    and output a requirements.txt fragment (with pinned version and hash)
+  workspaces:
+    - name: source_code
+      readonly: true
+      description: The package to build
+    - name: wheel_storage
+      description: The output to put the built wheel
+  results:
+    - name: requirements_line
+      type: string
+      description: Line suitable for a pinned requirements file for installing the built wheel
+  stepTemplate:
+    image: registry.access.redhat.com/ubi9-micro
+  steps:
+    - name: build-wheel
+      command:
+        - /usr/bin/python
+      args:
+        - -m
+        - build
+        - --outdir
+        - $(workspaces.wheel_storage.path)
+        - $(workspaces.source_code.path)
+    - script: |
+         pip hash $(workspaces.wheel_storage.path)/*.whl | sed -e '1s#^dist/\([^-]*\)-\([^-]*\).*#\1==\2 #' -e 'N; s/\n//' > $(results.requirements_line.path)


### PR DESCRIPTION
This intend to implement a git-repo pipeline which would not depend on an aicoe-ci.yaml file at the repository root.
The general idea:
- [x] build a python wheel from the source code (require a PEP 517 conforming project)
- [x] emit a 'package==version --hash=hashspec' line to feed into pip 
- [ ] use [Core-Metadata](https://packaging.python.org/en/latest/specifications/core-metadata/) (Requires-Python, in particular) to determine the base image to use.
- [ ] integrate/adapt into the PackageList pipeline:
  - [ ] optional 'built wheel' workspace
  - [ ] appending requirements line to requirements-pinned + add `--find-links` to pip command-line


(feedback on the idea welcome)
