### PR TITLE
Update the controller version tag to match the current version

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -40,4 +40,4 @@ k8s_yaml('hack/cre-prepare.yaml')
 
 k8s_yaml(kustomize('config/default'))
 
-podman_build('quay.io/thoth-station/meteor-operator:v0.1.0', '.')
+podman_build('quay.io/thoth-station/meteor-operator:v0.2.0', '.')

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,16 +1,16 @@
 resources:
-  - manager.yaml
+- manager.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-  - files:
-      - controller_manager_config.yaml
-    name: manager-config
+- files:
+  - controller_manager_config.yaml
+  name: manager-config
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: controller
-    newName: quay.io/thoth-station/meteor-operator
-    newTag: v0.1.0
+- name: controller
+  newName: quay.io/thoth-station/meteor-operator
+  newTag: v0.2.0

--- a/config/manifests/bases/meteor-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/meteor-operator.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
       Project Meteor provides a single click deployment for data science
       projects
     repository: https://github.com/thoth-station/meteor-operator
-  name: meteor-operator.v0.1.0
+  name: meteor-operator.v0.2.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 const (
-	Version = "0.1.0"
+	Version = "0.2.0"
 )


### PR DESCRIPTION
This PR updates the version tag of the controller in `config/manager/` to match the current tag.

This is necessary for the deployment of the operator in the OSC cluster, which uses these manifests for the deployment.

While the only update strictly needed for the deployment is under `config/manager/`, the PR also updates other references to the version for consistency.