### PR TITLE
Fix label and annotation handling in the import pipeline

### DIFF
--- a/pipelines/pipelines/cre-import.yaml
+++ b/pipelines/pipelines/cre-import.yaml
@@ -50,7 +50,7 @@ spec:
             apiVersion: image.openshift.io/v1
             metadata:
               annotations:
-                opendatahub.io/notebook-image-desc: $(params.description)
+                opendatahub.io/notebook-image-desc: "$(params.description)"
                 opendatahub.io/notebook-image-messages: ''
                 opendatahub.io/notebook-image-name: $(params.name)
                 opendatahub.io/notebook-image-phase: Validating
@@ -165,18 +165,8 @@ spec:
 
             cat <<EOM > patch-file.yaml
             metadata:
-              annotations:
-                opendatahub.io/notebook-image-messages: |
-                  $MESSAGES
-                opendatahub.io/notebook-image-phase: "$PHASE"
-            EOM
-
-            [ "$VISIBLE" == "true" ] && cat <<EOM >> patch-file.yaml
               labels:
-                opendatahub.io/notebook-image: 'true'
-            EOM
-
-            cat <<EOM >> patch-file.yaml
+                opendatahub.io/notebook-image: "$VISIBLE"
             spec:
               tags:
                 - annotations:
@@ -192,3 +182,7 @@ spec:
             EOM
 
             oc patch imagestream $(context.pipelineRun.name) -n $(context.pipelineRun.namespace) --type="merge" --patch-file patch-file.yaml
+
+            oc annotate imagestream $(context.pipelineRun.name) -n $(context.pipelineRun.namespace) --overwrite \
+                opendatahub.io/notebook-image-phase="$PHASE" \
+                opendatahub.io/notebook-image-messages="$MESSAGES"


### PR DESCRIPTION
Fixes: #155
Fixes: #159

by using `oc annotate` for the annotation updates (instead of including them in a patch), and by always adding the `notebook-image` label.

Tested with a CRE that attempts an import of an image that does not meet the Python version criteria:

``` yaml
apiVersion: meteor.zone/v1alpha1
kind: CustomRuntimeEnvironment
metadata:
  name: s2i-minimal-broken-import
  labels:
    app.kubernetes.io/created-by: cpe-_a-meteor.zone-CRE-v0.1.0
  annotations:
    opendatahub.io/notebook-image-name: s2i-minimal-broken-import
    opendatahub.io/notebook-image-desc: old minimal notebook image
    opendatahub.io/notebook-image-creator: codificat
spec:
  buildType: ImageImport
  fromImage: quay.io/thoth-station/s2i-minimal-notebook:v0.0.15
```

Output of `oc get is -o json | jq '.items[].metadata|{annotations,labels}'`:

``` json
{
  "annotations": {
    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"image.openshift.io/v1\",\"kind\":\"ImageStream\",\"metadata\":{\"annotations\":{\"opendatahub.io/notebook-image-creator\":\"codificat\",\"opendatahub.io/notebook-image-desc\":\"old minimal notebook image\",\"opendatahub.io/notebook-image-messages\":\"\",\"opendatahub.io/notebook-image-name\":\"s2i-minimal-broken-import\",\"opendatahub.io/notebook-image-origin\":\"Admin\",\"opendatahub.io/notebook-image-phase\":\"Validating\",\"opendatahub.io/notebook-image-url\":\"quay.io/thoth-station/s2i-minimal-notebook:v0.0.15\"},\"labels\":{\"app.kubernetes.io/part-of\":\"meteor-operator\"},\"name\":\"cre-s2i-minimal-broken-import-import\",\"namespace\":\"aicoe-meteor\"},\"spec\":{\"lookupPolicy\":{\"local\":true},\"tags\":[]}}\n",
    "opendatahub.io/notebook-image-creator": "codificat",
    "opendatahub.io/notebook-image-desc": "old minimal notebook image",
    "opendatahub.io/notebook-image-messages": "[{\"severity\":\"error\",\"message\":\"Python version does not meet minimal required version ('3.8.0')\"}]",
    "opendatahub.io/notebook-image-name": "s2i-minimal-broken-import",
    "opendatahub.io/notebook-image-origin": "Admin",
    "opendatahub.io/notebook-image-phase": "Failed",
    "opendatahub.io/notebook-image-url": "quay.io/thoth-station/s2i-minimal-notebook:v0.0.15",
    "openshift.io/image.dockerRepositoryCheck": "2022-12-15T18:50:35Z"
  },
  "labels": {
    "app.kubernetes.io/part-of": "meteor-operator",
    "opendatahub.io/notebook-image": "false"
  }
}
```

Pipeline run logs:

``` text
[create-imagestream : oc] Creating image stream:
[create-imagestream : oc]   Name:       cre-s2i-minimal-broken-import-import
[create-imagestream : oc]   Namespace:  aicoe-meteor
[create-imagestream : oc] 
[create-imagestream : oc]   Image name:        s2i-minimal-broken-import
[create-imagestream : oc]   Image description: old minimal notebook image
[create-imagestream : oc]   Image URL:         quay.io/thoth-station/s2i-minimal-notebook:v0.0.15
[create-imagestream : oc] 
[create-imagestream : oc]   Creator:           codificat
[create-imagestream : oc]   Phase:             Validating
[create-imagestream : oc]   Messages:          ''
[create-imagestream : oc]   Visibility:        false
[create-imagestream : oc]   Origin:            Admin
[create-imagestream : oc] 
[create-imagestream : oc] imagestream.image.openshift.io/cre-s2i-minimal-broken-import-import created

[setup : setup] Creating output files... DONE
[setup : setup] Verifying image is pull-able... DONE

[validate : get-package-versions] Analyzing image:
[validate : get-package-versions]     Python:             3.6.8
[validate : get-package-versions]     Python packages:    jupyter-kernel-gateway==2.4.0 jupyter-nbrequirements==0.7.3 jupyterhub==1.3.0 jupyterlab==3.0.14 jupyterlab-git==0.30.0b2 mod-wsgi==4.6.8 pipenv==2020.11.15 supervisor==4.1.0
[validate : get-package-versions]     R (optional):       Not available
[validate : get-package-versions]     RStudio (optional): Not available

[validate : minimal-requirements] Validating minimal requirements:
[validate : minimal-requirements]     Python >= 3.8.0 ❌
[validate : minimal-requirements]     'jupyterhub' package is present ✅
[validate : minimal-requirements]     'jupyterlab' package is present ✅
[validate : minimal-requirements]     $HOME is writeable ✅
[validate : minimal-requirements]     start-singleuser.sh is present  ✅
[validate : minimal-requirements]     start-singleuser.sh must execute 'jupyter'  ✅
[validate : minimal-requirements]     start-singleuser.sh must start 'labhub' environment  ✅
[validate : minimal-requirements]     start-singleuser.sh must accept runtime args or pass a config file  ✅

[update-imagestream : oc] Updating image stream:
[update-imagestream : oc]   Name:       cre-s2i-minimal-broken-import-import
[update-imagestream : oc]   Namespace:  aicoe-meteor
[update-imagestream : oc] 
[update-imagestream : oc]   Image tag:           v0.0.15
[update-imagestream : oc]   Phase:               Failed
[update-imagestream : oc]   Messages:            [{"severity":"error","message":"Python version does not meet minimal required version ('3.8.0')"}]
[update-imagestream : oc]   Visibility:          false
[update-imagestream : oc]   Software:            [{"name":"Python","version":"3.6.8"}]
[update-imagestream : oc]   Python dependencies: [{"name": "jupyter-kernel-gateway", "version": "2.4.0", "visible": true}, {"name": "jupyter-nbrequirements", "version": "0.7.3", "visible": true}, {"name": "jupyterhub", "version": "1.3.0", "visible": true}, {"name": "jupyterlab", "version": "3.0.14", "visible": true}, {"name": "jupyterlab-git", "version": "0.30.0b2", "visible": true}, {"name": "mod-wsgi", "version": "4.6.8", "visible": true}, {"name": "pipenv", "version": "2020.11.15", "visible": true}, {"name": "supervisor", "version": "4.1.0", "visible": true}]
[update-imagestream : oc] 
[update-imagestream : oc] imagestream.image.openshift.io/cre-s2i-minimal-broken-import-import patched
[update-imagestream : oc] imagestream.image.openshift.io/cre-s2i-minimal-broken-import-import annotated
```