### PR TITLE
change tekton pipeline metadata to generatename

### DIFF
--- a/controllers/cre/controller.go
+++ b/controllers/cre/controller.go
@@ -109,8 +109,8 @@ func (r *CustomRuntimeEnvironmentReconciler) reconcilePipelineRun(ctx context.Co
 	pipeline := build_types[cre.Spec.BuildType]
 	pipelineRun := &pipelinev1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("cre-%s-%s", cre.GetName(), pipeline),
-			Namespace: cre.Namespace,
+			GenerateName: fmt.Sprintf("cre-%s-%s-", cre.GetName(), pipeline),
+			Namespace:    cre.Namespace,
 			Labels: map[string]string{
 				"cre.thoth-station.ninja/pipeline": build_types[cre.Spec.BuildType],
 			}}}
@@ -137,6 +137,7 @@ func (r *CustomRuntimeEnvironmentReconciler) reconcilePipelineRun(ctx context.Co
 		if errors.IsNotFound(err) {
 			logger.Info("Creating PipelineRun")
 
+			// TODO: replace ArrayOrString (deprecated) https://github.com/tektoncd/pipeline/blob/75d0037daf06664cb93efe86d974e1fbf69cbbbe/pkg/apis/pipeline/v1beta1/param_types.go#L140
 			// let's put the mandatory annotations into the PipelineRun
 			params := []pipelinev1beta1.Param{
 				{


### PR DESCRIPTION
Signed-off-by: Kevin <kpostlet@redhat.com>

## Related Issues and Dependencies
fixes #97 

## This introduces a breaking change
<!-- Leave one of the options -->

- Yes
- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This should yield a new module release

- Yes
- No

<!-- If this change modifies the behavior of the module, specify that it should yield a new minor release. -->

## This Pull Request implements
This is just changing to using generate name for the PipelineRun resource. I'm unsure what other changes need to be done wrt the rest of the reconciliation loop.
