### PR TITLE
Use declarative conditions for the CRE status.

### DIFF
--- a/api/v1alpha1/cre_condition_consts.go
+++ b/api/v1alpha1/cre_condition_consts.go
@@ -40,11 +40,13 @@ const (
 	// - NewCreVersion
 
 	// The last pipeline building the image errored out.
-	BuildFailing = "BuildFailing"
+	LatestBuildSucceeded = "LatestBuildSucceeded"
 
-	// Reasons for (False -> True):
-	// - PipelineSucceded
-	// Reasons for (True -> False):
-	// - PipelineFailed
+	// Reasons for (True -> Unknown || False -> Unknown)
+	// - NewPipelineRun
+	// Reasons for (Unknown -> True):
+	// - PipelineRunSucceeded
+	// Reasons for (Unknown -> False):
+	// - PipelineRunFailed
 	// More detailed causes of failure for pipelines should use the metav1.Condition.Message field
 )

--- a/api/v1alpha1/cre_condition_consts.go
+++ b/api/v1alpha1/cre_condition_consts.go
@@ -19,42 +19,32 @@ limitations under the License.
 package v1alpha1
 
 const (
-	// PipelineRunCreated indicates that the Tekton pipeline run was created
-	PipelineRunCreated = "PipelineRunCreated"
 
-	// ErrorPipelineRunCreate indicates that the Tekton pipeline run creation failed
-	ErrorPipelineRunCreate = "ErrorPipelineRunCreate"
+	// There is at least one ImageStreamTag available in the corresponding ImageStream.
+	Ready = "Ready"
 
-	// ImportingImage indicates that the image is being imported from a remote registry
-	ImportingImage = "ImportingImage"
+	// Reasons for (False -> True):
+	// - ImagePushed
+	// Reasons for (True -> False):
+	// - ImageStreamDeleted
+	// - ImageTagDeleted
 
-	// RequredSecretMissing indicates that the secret required for authentication to the container image registry is missing
-	RequiredSecretMissing = "RequiredSecretMissing"
+	// The ImageStreamTag corresponding to the current CRE observedGeneration exists.
+	ImageUpToDate = "ImageUpToDate"
 
-	// ValidatingImportedImage indicates that the imported image is being validated by a Tekton PipelineRun's Step
-	ValidatingImportedImage = "ValidatingImportedImage"
+	// Reasons for (False -> True):
+	// - ImagePushed
+	// Reasons for (True -> False):
+	// - ImageStreamDeleted
+	// - ImageTagDeleted
+	// - NewCreVersion
 
-	// ImageImportReady indicates that the imported image is ready to be used
-	ImageImportReady = "ImageImportReady"
+	// The last pipeline building the image errored out.
+	BuildFailing = "BuildFailing"
 
-	// ImageImportInvalid indicates that the imported image is invalid
-	ImageImportInvalid = "ImageImportInvalid"
-
-	// ErrorResolvingDependencies indicates that the dependency resolution failed during preparation of the image build
-	ErrorResolvingDependencies = "ErrorResolvingDependencies"
-
-	// BuildingImage indicates that the image is being built by a Tekton PipelineRun
-	BuildingImage = "BuildingImage"
-
-	// PackageListBuildCompleted indicates that the package list build completed
-	PackageListBuildCompleted = "PackageListBuildCompleted"
-
-	// ErrorBuildingImage indicates that the image build failed
-	ErrorBuildingImage = "ErrorBuildingImage"
-
-	// GenericPipelineError indicates that the pipeline failed with an error
-	GenericPipelineError = "GenericPipelineError"
-
-	// PipelineRunCompleted indicates that the Tekton pipeline run completed
-	PipelineRunCompleted = "PipelineRunCompleted"
+	// Reasons for (False -> True):
+	// - PipelineSucceded
+	// Reasons for (True -> False):
+	// - PipelineFailed
+	// More detailed causes of failure for pipelines should use the metav1.Condition.Message field
 )


### PR DESCRIPTION
We reduce the API surface with less conditions, trying to describe the
state of our resource.
The API is built around the assumption that client only cares about
three things:
- Is there a built image available ? (-> can I run it ?)
- Is the image up to date ? (-> are my last changes in it ?)
- Is there an error ? (-> are my changes correct / is the cluster not
  working ?)

Open questions:
- I wonder if we need a fourth "transient" condition, BuildScheduled/equivalent ?
  Is there an use case (aka, a API client who cares) for it ?

This is only the API side, on which we should agree before adapting the reconciliation loop inside the controller.

I left out Thoth-related conditions for now, this should be additive and not modify the core logic of CRE, I think.

@goern @codificat



## Related Issues and Dependencies
fixes: #130

## This introduces a breaking change

- Yes

## This should yield a new module release

- Yes
